### PR TITLE
Add the appropriate amount of padding

### DIFF
--- a/src/templates/apply.js
+++ b/src/templates/apply.js
@@ -21,18 +21,7 @@ export const ROLE_COLOR_MAPPING = {
 const BlueFontSection = styled(Section)`
   color: ${SB_NAVY};
   padding-bottom: 50px;
-
-  @media (min-height: 750px) {
-    padding-bottom: 150px;
-  }
-
-  @media (min-height: 1000px) {
-    padding-bottom: 300px;
-  }
-
-  @media (min-height: 1350px) {
-    padding-bottom: 600px;
-  }
+  min-height: 75vh;
 `
 
 const Header = styled.h1`

--- a/src/templates/apply.js
+++ b/src/templates/apply.js
@@ -20,7 +20,19 @@ export const ROLE_COLOR_MAPPING = {
 
 const BlueFontSection = styled(Section)`
   color: ${SB_NAVY};
-  height: 75vh;
+  padding-bottom: 50px;
+
+  @media (min-height: 750px) {
+    padding-bottom: 150px;
+  }
+
+  @media (min-height: 1000px) {
+    padding-bottom: 300px;
+  }
+
+  @media (min-height: 1350px) {
+    padding-bottom: 600px;
+  }
 `
 
 const Header = styled.h1`
@@ -46,7 +58,6 @@ const Subtitle = styled.h3`
 
 const CenteredContent = styled.div`
   text-align: center;
-  margin: auto;
 `
 
 const ApplyPage = ({ data, pageContext }) => {


### PR DESCRIPTION
Hacky bug fix to add the appropriate amount of padding.

Longer term fix should involve the footer always going to the bottom of the screen if there isn't enough content to fill up the screen. Will open a new issue for that.