### PR TITLE
Update jaime's link

### DIFF
--- a/src/content/team/team.json
+++ b/src/content/team/team.json
@@ -384,7 +384,7 @@
       "socialMedia": {
         "email": "gonora.j@northeastern.edu",
         "linkedIn": "https://www.linkedin.com/in/JaimeGonora",
-        "portfolio": "www.jaimegonora.com"
+        "portfolio": "https://www.jaimegonora.com/"
       }
     },
     {


### PR DESCRIPTION
This PR adds https to jaime's link because if it doesn't have that, it will direct to `https://www.sandboxnu.com/www.jaimegonora.com` instead of a new page