### PR TITLE
[Recruiting] Site Updates - Fall Cycle 2023 

### DIFF
--- a/now.json
+++ b/now.json
@@ -36,7 +36,7 @@
       "src": "/how-we-recruit",
       "status": 301,
       "headers": {
-        "Location": "https://example.com/notion-article-goes-here"
+        "Location": "https://sandboxnu.notion.site/How-Sandbox-Recruits-2ff41c657d79451da91da8c659f50f56"
       }
     },
     {

--- a/now.json
+++ b/now.json
@@ -31,6 +31,34 @@
       "headers": {
         "Location": "https://medium.com/@dajinchu/how-sandbox-can-help-researchers-b5dbddeecf14"
       }
+    },
+    {
+      "src": "/how-we-recruit",
+      "status": 301,
+      "headers": {
+        "Location": "https://example.com/notion-article-goes-here"
+      }
+    },
+    {
+      "src": "/apply/developer/form",
+      "status": 301,
+      "headers": {
+        "Location": "https://docs.google.com/forms/d/e/1FAIpQLSe7AieWIDRQg1548A9EsH1l7U7mUBZOeUl4hecZVj4MzzicWg/viewform"
+      }
+    },
+    {
+      "src": "/apply/ux-designer/form",
+      "status": 301,
+      "headers": {
+        "Location": "https://docs.google.com/forms/d/e/1FAIpQLSe4aXIwHIBk2VTGOHtJTRIFML834OPKByHMEdLt23-H54yhvA/viewform"
+      }
+    },
+    {
+      "src": "/apply/brand-designer/form",
+      "status": 301,
+      "headers": {
+        "Location": "https://docs.google.com/forms/d/e/1FAIpQLSe4aXIwHIBk2VTGOHtJTRIFML834OPKByHMEdLt23-H54yhvA/viewform"
+      }
     }
   ],
   "alias": ["www.sandboxnu.com"]

--- a/src/components/ApplyPage/howSandboxRecruits.js
+++ b/src/components/ApplyPage/howSandboxRecruits.js
@@ -1,0 +1,56 @@
+import { SB_NAVY, SB_BUTTON_BLUE, SB_SALMON, SB_INK } from "@colors"
+import React from "react"
+import styled from "styled-components"
+import Section from "styles/components/Section"
+import { Header } from "styles/components/Header"
+import Button from "components/ApplyPage/button"
+
+const RecruitingSection = styled(Section)`
+  background-color: #FFFFFF;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: none;
+  padding: 5em 4em;
+
+  @media (min-width: 1000px) {
+    min-height: 20vh;
+    max-width: 100vw;
+  }
+
+  @media (max-width: 1100px) {
+    display: block;
+    max-width: 100%;
+  }
+
+  @media (max-width: 600px) {
+    padding: 2.5em;
+    max-width: 100vw;
+  }
+`
+
+const SectionHeader = styled(Header)`
+  color: ${SB_NAVY};
+  font-size: 4em;
+  letter-spacing: 0.02em;
+  margin-top: 0;
+
+  @media (max-width: 600px) {
+    font-size: 3em;
+  }
+`
+
+const HowSandboxRecruits = () => {
+  return (
+    <RecruitingSection>
+        <SectionHeader>How we recruit</SectionHeader>
+        <Button
+          name={<span>Read our article: <b>How Sandbox Recruits</b>!</span>}
+          route={"/how-we-recruit"}/>
+    </RecruitingSection>
+  )
+}
+
+export default HowSandboxRecruits;

--- a/src/components/ApplyPage/positions.js
+++ b/src/components/ApplyPage/positions.js
@@ -87,10 +87,10 @@ const Positions = ({ positions }) => {
                 Our teams consist of developers, a project lead, and often 
                 a UX designer. Here are our current positions.
               </BodyText>
-              <Button
+              {/* <Button
                 name="Join our community Slack"
                 route="https://join.slack.com/t/sandboxcommunity/shared_invite/zt-1khg7tjb7-kMtYwrWgNmzQ_hdTg0S1og"
-              ></Button>
+              ></Button> */}
             </HeaderColumn>
             <ParagraphContainer>{positions}</ParagraphContainer>
           </TwoColumn>

--- a/src/components/ApplyPage/recruiting.js
+++ b/src/components/ApplyPage/recruiting.js
@@ -119,7 +119,7 @@ const Recruiting = () => {
         </BodyText>
         <TracksContainer>
           <Track>
-            <TrackHeader>Catepillar</TrackHeader>
+            <TrackHeader>Caterpillar</TrackHeader>
             <TrackDescription>
               For students who have completed Fundies 1 and maybe Fundies 2, might be 
               taking OOD over the summer, and don’t have an extensive background in CS 

--- a/src/components/ApplyPage/recruiting.js
+++ b/src/components/ApplyPage/recruiting.js
@@ -119,7 +119,7 @@ const Recruiting = () => {
         </BodyText>
         <TracksContainer>
           <Track>
-            <TrackHeader>Fundies</TrackHeader>
+            <TrackHeader>Catepillar</TrackHeader>
             <TrackDescription>
               For students who have completed Fundies 1 and maybe Fundies 2, might be 
               taking OOD over the summer, and don’t have an extensive background in CS 
@@ -127,7 +127,7 @@ const Recruiting = () => {
             </TrackDescription>
           </Track>
           <Track>
-            <TrackHeader>Algo/OOD</TrackHeader>
+            <TrackHeader>Chrysalis</TrackHeader>
             <TrackDescription>
               For students who have completed OOD and have either taken or are taking Algo. 
               Students might be applying for their first co-op, just started one, or completed 
@@ -135,7 +135,7 @@ const Recruiting = () => {
             </TrackDescription>
           </Track>
           <Track>
-            <TrackHeader>Web-dev</TrackHeader>
+            <TrackHeader>Butterfly/Moth</TrackHeader>
             <TrackDescription>
               For students who have developed a frontend or backend for a web application, 
               especially those who have experience with it from a co-op or an internship. 

--- a/src/content/apply/apply.json
+++ b/src/content/apply/apply.json
@@ -3,6 +3,6 @@
   "subtitle": "As Sandbox continues to grow, we aim to build a diverse and skilled team of developers with a variety of experiences, interests, and backgrounds.",
   "quote": "\"People are very caring and just great to get along with. Projects are challenging, but the opportunities you get to push yourself and develop features, that seem like a distant idea otherwise, are amazing.\"",
   "quoteReference": "Christina Long, Project Lead of Faculty Activity Tracker ",
-  "applicationStatus": "Spring 2023 Applications are open",
+  "applicationStatus": "Fall 2023 Applications are open",
   "isBannerVisible": false
 }

--- a/src/content/apply/brand-designer.md
+++ b/src/content/apply/brand-designer.md
@@ -9,14 +9,14 @@ qualities:
   - Communicates well
   - Is kind
   - Can commit to 10 hours a week
-formLink: "https://forms.gle/K6kSapV7CTxPVNra6"
+formLink: "/apply/brand-designer/form"
 mailLink: "https://gmail.us3.list-manage.com/subscribe?u=3b3ae33f54203ab7a839ae529&id=c2570dd048"
 role: Brand Designer
 description: We’re looking for brand designers to design branding, promotional material (digital and paper), graphics, and merch while utilizing and expanding upon our current brand guides. As a brand designer in Sandbox, you’ll work with other brand designers, the director of marketing and events, and the director of UX to continuously promote Sandbox and improve its public image.
 isVisible: true
 isOpen: true
-openDate: "November 28th 2022"
-closeDate: "December 11th 2022"
+openDate: "May 27th 2023"
+closeDate: "June 2nd 2023"
 ---
 
 Sandbox is Northeastern’s student led software consultancy that aims to unleash the power of student-driven software. We build solutions to accelerate research for scientists, as well as in-house tools for the Northeastern community, such as [searchneu.com](https://searchneu.com) and [GraduateNU](https://graduatenu.com) (a tool to help students build a plan of study).

--- a/src/content/apply/brand-designer.md
+++ b/src/content/apply/brand-designer.md
@@ -16,7 +16,7 @@ description: We’re looking for brand designers to design branding, promotional
 isVisible: true
 isOpen: true
 openDate: "May 27th 2023"
-closeDate: "June 2nd 2023"
+closeDate: "June 4th 2023"
 ---
 
 Sandbox is Northeastern’s student led software consultancy that aims to unleash the power of student-driven software. We build solutions to accelerate research for scientists, as well as in-house tools for the Northeastern community, such as [searchneu.com](https://searchneu.com) and [GraduateNU](https://graduatenu.com) (a tool to help students build a plan of study).

--- a/src/content/apply/developer.md
+++ b/src/content/apply/developer.md
@@ -6,14 +6,14 @@ qualities:
   - Is kind
   - Takes on leadership role to help out teammates
   - Can commit to 10 hours a week
-formLink: "https://forms.gle/TK4Dcc5eqNRaWdct5"
+formLink: "/apply/developer/form"
 mailLink: "https://gmail.us3.list-manage.com/subscribe?u=3b3ae33f54203ab7a839ae529&id=c2570dd048"
 role: Developer
 description: "We're looking for developers to work on research projects with researchers and professors as well as community projects for the Northeastern student body. We have frontend, backend, and full stack developers who are passionate about contributing to the community. As Sandbox continues to grow, we’re building a diverse and skilled team of developers with a variety of experiences, interests, and backgrounds to make amazing software with us."
 isVisible: true
 isOpen: true
-openDate: "November 28th 2022"
-closeDate: "December 11th 2022"
+openDate: "May 27th 2023"
+closeDate: "June 2nd 2023"
 quote: "People are very caring and just great to get along with. Projects are challenging, but the opportunities you get to push yourself and develop features, that seem like a distant idea otherwise, are amazing. For me that was OAuth. Being able to learn authentication and create a system with working Google authentication was a goal of mine for a long time. I was very happy to be able to achieve that goal while also working on a project that benefited the community."
 quoteMember: "Christina Long"
 quoteMemberTitle: "Developer on Know Your Options"

--- a/src/content/apply/developer.md
+++ b/src/content/apply/developer.md
@@ -13,7 +13,7 @@ description: "We're looking for developers to work on research projects with res
 isVisible: true
 isOpen: true
 openDate: "May 27th 2023"
-closeDate: "June 2nd 2023"
+closeDate: "June 4th 2023"
 quote: "People are very caring and just great to get along with. Projects are challenging, but the opportunities you get to push yourself and develop features, that seem like a distant idea otherwise, are amazing. For me that was OAuth. Being able to learn authentication and create a system with working Google authentication was a goal of mine for a long time. I was very happy to be able to achieve that goal while also working on a project that benefited the community."
 quoteMember: "Christina Long"
 quoteMemberTitle: "Developer on Know Your Options"

--- a/src/content/apply/ux-designer.md
+++ b/src/content/apply/ux-designer.md
@@ -7,14 +7,14 @@ qualities:
   - Works well in teams
   - Is kind
   - Can commit to 10 hours a week
-formLink: "https://forms.gle/cjHN3dWHxpCGkRdn9"
+formLink: "/apply/ux-designer/form"
 mailLink: "https://gmail.us3.list-manage.com/subscribe?u=3b3ae33f54203ab7a839ae529&id=c2570dd048"
 role: UX Designer
 description: We're looking for UX designers to join our project teams and make direct contributions towards building projects for researchers, professors, and the Northeastern student body. They work hand in hand with their teams to design stunning user experiences and deliver real applications to production.
 isVisible: true
 isOpen: true
-openDate: "November 28th 2022"
-closeDate: "December 11th 2022"
+openDate: "May 27th 2023"
+closeDate: "June 2nd 2023"
 quote: "The most tight-knit, supportive community I have ever been part of, but also the most talented yet fun people I've ever met. Genuinely not exaggerated at all, they are some of the MOST talented people I know who know how to enjoy life too."
 quoteMember: "Christine Cho"
 quoteMemberTitle: "Designer on EdLaw"

--- a/src/content/apply/ux-designer.md
+++ b/src/content/apply/ux-designer.md
@@ -14,7 +14,7 @@ description: We're looking for UX designers to join our project teams and make d
 isVisible: true
 isOpen: true
 openDate: "May 27th 2023"
-closeDate: "June 2nd 2023"
+closeDate: "June 4th 2023"
 quote: "The most tight-knit, supportive community I have ever been part of, but also the most talented yet fun people I've ever met. Genuinely not exaggerated at all, they are some of the MOST talented people I know who know how to enjoy life too."
 quoteMember: "Christine Cho"
 quoteMemberTitle: "Designer on EdLaw"

--- a/src/pages/apply.js
+++ b/src/pages/apply.js
@@ -8,7 +8,7 @@ import Values from "../components/ApplyPage/values"
 import Layout from "../components/PageLayout/layout"
 import Quote from "components/ApplyPage/quote"
 import SEO from "components/seo"
-import Recruiting from "../components/ApplyPage/recruiting"
+import HowSandboxRecruits from "../components/ApplyPage/howSandboxRecruits"
 
 const ApplyPage = ({ data }) => {
   const {
@@ -41,7 +41,7 @@ const ApplyPage = ({ data }) => {
       <Quote text={quote} reference={quoteReference} />
       <Values {...data.values.edges[0].node} />
       <Positions positions={positions}/>
-      <Recruiting />
+      <HowSandboxRecruits />
     </Layout>
   )
 }


### PR DESCRIPTION
Makes some tweaks to the site in preparation for Fall 2023 applications!

- Added 4 redirects for forms/pages that might update in future so we can change them without changing the link
    - /apply/developer/form -> Current Developer Application
    - /apply/ux-designer/form -> Current UX Designer Application
    - /apply/brand-designer/form -> Current Brand Designer Application
    - /how-we-recruit -> Current version of How Sandbox Recruits
- Replaced the on-site How We Recruit section with a link to the Notion article
- Various copy/date updates for the new cycle