### PR TITLE
Close Apps for Spring 2025

### DIFF
--- a/src/content/apply/apply.json
+++ b/src/content/apply/apply.json
@@ -3,6 +3,6 @@
   "subtitle": "As Sandbox continues to grow, we aim to build a diverse and skilled team of developers with a variety of experiences, interests, and backgrounds.",
   "quote": "\"People are very caring and just great to get along with. Projects are challenging, but the opportunities you get to push yourself and develop features, that seem like a distant idea otherwise, are amazing.\"",
   "quoteReference": "Christina Long, Project Lead of Faculty Activity Tracker ",
-  "applicationStatus": "Applications for Spring 2025 are now open!",
+  "applicationStatus": "Applications for Spring 2025 are now closed",
   "isBannerVisible": false
 }

--- a/src/content/faqs/faqs.json
+++ b/src/content/faqs/faqs.json
@@ -10,7 +10,7 @@
     },
     {
       "question": "when do applications open?",
-      "answer": "Applications for Spring 2025 are open now through December 8th. Be sure to follow our social media and subscribe to our mailing list to get the latest updates!"
+      "answer": "Applications for Spring 2025 are now closed. Be sure to follow our social media and subscribe to our mailing list to get the latest updates!"
     },
     {
       "question": "what is oasis?",

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -56,7 +56,7 @@ const AboutPage = ({ data }) => {
       <Banner>
         <JoinBannerContent>
           <div>JOIN OUR TEAM</div>
-          <span>Applications for Spring 2025 are now open!</span>
+          <span>Applications for Spring 2025 are now closed</span>
         </JoinBannerContent>
       </Banner>
     </Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -37,7 +37,7 @@ const IndexPage = ({ data }) => {
       <Banner>
         <JoinBannerContent>
           <div>JOIN OUR TEAM</div>
-          <span>Applications for Spring 2025 are now open!</span>
+          <span>Applications for Spring 2025 are now closed</span>
         </JoinBannerContent>
       </Banner>
     </Layout>


### PR DESCRIPTION
This pull request includes several updates to reflect that applications for Spring 2025 are now closed. The most important changes include updates to JSON content files and banner messages on the website.

Updates to application status:

* [`src/content/apply/apply.json`](diffhunk://#diff-d6bf8bccc286166e77bbcc0f4640ab8ac5856c0c73b7a5ec3805ccb48baa3314L6-R6): Changed the application status message to indicate that applications for Spring 2025 are now closed.
* [`src/content/faqs/faqs.json`](diffhunk://#diff-7a195cd2ab877f3854ef9a4a2f0f07bc43cb8dc57932415150e3915a7fb02033L13-R13): Updated the FAQ answer to reflect that applications for Spring 2025 are now closed.

Updates to website banners:

* [`src/pages/about.js`](diffhunk://#diff-216b47bbd04e380a13f3c26b01dfe43aa400bdb907ad9352fd54cd3ea99495f5L59-R59): Modified the banner message on the About page to indicate that applications for Spring 2025 are now closed.
* [`src/pages/index.js`](diffhunk://#diff-26ca35c3be6d07c84bb77f1e63a1b19487279d5b9c9a9392179b3a35647e1254L40-R40): Updated the banner message on the Index page to indicate that applications for Spring 2025 are now closed.