### PR TITLE
Node update

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier": "^2.2.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": "22.x"
   },
   "keywords": [
     "gatsby"


### PR DESCRIPTION
greater than =14 still made the deployment fail so I think just hard setting it to 22 will do the job.